### PR TITLE
Update the deployed documentation Doxygen version

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -11,6 +11,9 @@ jobs:
 
         steps:
         - uses: actions/checkout@v3
+        
+        - name: Install dependencies
+          run: sudo apt-get install -y doxygen
 
         - name: Generate Doxyfile through CMake
           run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,20 +13,15 @@ jobs:
         - uses: actions/checkout@v3
         
         - name: Install dependencies
-          run: sudo apt-get install -y graphviz cmake
-          
-        - name: Build latest Doxygen from source
-          run: mkdir doxygen-build
-            && git clone https://github.com/doxygen/doxygen doxygen-build
-            && cd doxygen-build
-            && cmake -G "Unix Makefiles" .
-            && make install
+          run: sudo apt-get install -y doxygen graphviz
 
         - name: Generate Doxyfile through CMake
-          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF
-
+          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF && ls /home/runner/work/orion_vk/orion_vk/build && cat /home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
+          
         - name: Build HTML documentation
-          run: cmake --build cd /home/runner/work/orion_vk/orion_vk/build/
+          uses: mattnotmitt/doxygen-action@1.9.1
+          with:
+            working-directory: /home/runner/work/orion_vk/orion_vk/build/docs
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,15 +13,20 @@ jobs:
         - uses: actions/checkout@v3
         
         - name: Install dependencies
-          run: sudo apt-get install -y doxygen graphviz
+          run: sudo apt-get install -y graphviz cmake
+          
+        - name: Build latest Doxygen from source
+          run: mkdir doxygen-build
+            && git clone https://github.com/doxygen/doxygen doxygen-build
+            && cd doxygen-build
+            && cmake -G "Unix Makefiles" .
+            && make install
 
         - name: Generate Doxyfile through CMake
-          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF && ls /home/runner/work/orion_vk/orion_vk/build && cat /home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
-          
+          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF
+
         - name: Build HTML documentation
-          uses: mattnotmitt/doxygen-action@1.9.1
-          with:
-            doxyfile-path: ./home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
+          run: cmake --build cd /home/runner/work/orion_vk/orion_vk/build/
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -18,7 +18,8 @@ jobs:
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1
           with:
-            doxyfile-path: build/docs/Doxyfile
+            doxyfile-path: ./build/docs/Doxyfile
+            working-directory: orion_vk
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1
           with:
-            working-directory: /home/runner/work/orion_vk/orion_vk/build
+            working-directory: /home/runner/work/orion_vk/orion_vk/
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,13 +13,12 @@ jobs:
         - uses: actions/checkout@v3
 
         - name: Generate Doxyfile through CMake
-          run: cmake . -B build/ -DORION_BUILD_CORE=OFF
+          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF
           
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1
           with:
-            doxyfile-path: ./build/docs/Doxyfile
-            working-directory: orion_vk
+            doxyfile-path: /home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -16,12 +16,12 @@ jobs:
           run: sudo apt-get install -y doxygen graphviz
 
         - name: Generate Doxyfile through CMake
-          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF && ls /home/runner/work/orion_vk/orion_vk/build && cat /home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
+          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF && ls /home/runner/work/orion_vk/orion_vk/build
           
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1
           with:
-            working-directory: /home/runner/work/orion_vk/orion_vk/build/docs
+            working-directory: /home/runner/work/orion_vk/orion_vk/build
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -16,7 +16,7 @@ jobs:
           run: sudo apt-get install -y doxygen graphviz
 
         - name: Generate Doxyfile through CMake
-          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF
+          run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF && ls /home/runner/work/orion_vk/orion_vk/build && cat /home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
           
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,28 +12,20 @@ jobs:
         steps:
         - uses: actions/checkout@v3
 
-        - name: Prerequisites
+        - name: Install dependencies
           run: sudo apt install doxygen
 
-        - name: Configure
+        - name: Generate Doxyfile through CMake
           run: cmake . -B build/ -DORION_BUILD_CORE=OFF
+          
+        - name: Build HTML documentation
+          uses: mattnotmitt/doxygen-action@1.9.1
+          with:
+            doxygen-path: build/docs/Doxyfile
 
-        - name: Build
-          run: cmake --build build/
-            && cd build/docs/html
-            && touch .nojekyll
-
-        - name: Deploy
+        - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3
           with:
             GITHUB_TOKEN: ${{ github.token }}
             BRANCH: gh-pages
             FOLDER: build/docs/html
-
-        - name: Delete workflow runs
-          uses: Mattraks/delete-workflow-runs@v2
-          with:
-            token: ${{ github.token }}
-            repository: ${{ github.repository }}
-            retain_days: 0
-            keep_minimum_runs: 0

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-        - uses: actions/checkout@v3
+        - uses: actions/checkout@v1
         
         - name: Install dependencies
           run: sudo apt-get install -y doxygen graphviz

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -12,16 +12,13 @@ jobs:
         steps:
         - uses: actions/checkout@v3
 
-        - name: Install dependencies
-          run: sudo apt install doxygen
-
         - name: Generate Doxyfile through CMake
           run: cmake . -B build/ -DORION_BUILD_CORE=OFF
           
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1
           with:
-            doxygen-path: build/docs/Doxyfile
+            doxyfile-path: build/docs/Doxyfile
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -13,7 +13,7 @@ jobs:
         - uses: actions/checkout@v3
         
         - name: Install dependencies
-          run: sudo apt-get install -y doxygen
+          run: sudo apt-get install -y doxygen graphviz
 
         - name: Generate Doxyfile through CMake
           run: cd /home/runner/work/orion_vk/orion_vk && cmake . -B build/ -DORION_BUILD_CORE=OFF

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -21,7 +21,7 @@ jobs:
         - name: Build HTML documentation
           uses: mattnotmitt/doxygen-action@1.9.1
           with:
-            doxyfile-path: /home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
+            doxyfile-path: ./home/runner/work/orion_vk/orion_vk/build/docs/Doxyfile
 
         - name: Deploy resulting HTML
           uses: JamesIves/github-pages-deploy-action@releases/v3


### PR DESCRIPTION
The current Doxygen version being used is outdated, at 1.8.x instead of 1.9.x.

This results in a lot of annoying styling issues, and a very bad experience on mobile.

Hopefully using doxygen-action will help this problem.